### PR TITLE
Feature/retain card position and focus 

### DIFF
--- a/src/pages/AllArt.test.tsx
+++ b/src/pages/AllArt.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import AllArt from "../pages/AllArt";
 import { MemoryRouter } from "react-router-dom";
@@ -44,6 +44,12 @@ const mockResponse = {
 
 describe("AllArt Component", () => {
   beforeEach(() => {
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      writable: true,
+      value: jest.fn(),
+    });
+    localStorage.clear();
     jest.resetAllMocks();
   });
 
@@ -105,5 +111,32 @@ describe("AllArt Component", () => {
       screen.getByRole("button", { name: /previous/i })
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /next/i })).toBeInTheDocument();
+  });
+
+  it("should retain card position and focus when navigating back from detail page", async () => {
+    const { useGetArtCollection } = require("../hooks/useGetArtCollection");
+    useGetArtCollection.mockReturnValue({
+      data: mockResponse,
+      isLoading: false,
+      error: null,
+    });
+
+    const { unmount } = renderPage();
+
+    const artCard = await screen.findByAltText(/Alt text/i);
+    const cardLink = artCard.closest("a");
+    expect(cardLink).toBeInTheDocument();
+
+    fireEvent.click(cardLink!);
+    expect(localStorage.getItem("clickedArtId")).toBe("0-1");
+    unmount();
+    renderPage();
+
+    await waitFor(() => {
+      const cardDiv = document.getElementById("0-1") 
+      expect(cardDiv).toBeInTheDocument();
+      expect(cardDiv).toHaveClass("ring-2", "ring-red-500", "text-red-500");
+      expect(cardDiv?.scrollIntoView).toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
When the user navigates back from the detail view to the art list, the app scrolls the previously selected card into view and applies a visual highlight to it. This allows users to immediately recognize the card they were viewing and continue browsing without having to manually locate it.

- Scroll Restoration: The clicked card’s ID is stored (using localStorage) during navigation. When returning to the art list, the component retrieves this ID, locates the corresponding card element via React refs, and scrolls it into view using scrollIntoView.

- Visual Focus: The component applies Tailwind CSS focus classes (e.g., a ring and text color changes) to the selected card, offering a clear visual cue of which card was last interacted with.

- Refactoring & Testing: The feature uses React refs for precise element targeting, and tests have been added to ensure the scroll restoration and focus functionality work as expected.

<img width="1758" alt="Screenshot 2025-04-07 at 8 44 10 PM" src="https://github.com/user-attachments/assets/b3c538d0-551b-419d-8062-dd5d8b5d6555" />

